### PR TITLE
BaSP-MR-68: hotfix subscriptions bug

### DIFF
--- a/src/Components/Subscriptions/subscriptions.module.css
+++ b/src/Components/Subscriptions/subscriptions.module.css
@@ -11,7 +11,6 @@
   display: flex;
   flex-direction: column;
   width: 80%;
-  height: 650px;
   margin: 50px;
   background-color: rgba(55, 56, 103, 0.5);
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
It was only necessary to remove the "height" attribute from the styles of the subscriptions list to make it adapt and become scrollable.