### PR TITLE
BaSP-MR-71: added props (text and warning)

### DIFF
--- a/src/Components/Shared/Modal/index.jsx
+++ b/src/Components/Shared/Modal/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './modal.module.css';
 
-const Modal = ({ isOpen, onClose, title, children, success }) => {
+const Modal = ({ isOpen, onClose, title, text, children, success, warning }) => {
   if (!isOpen) {
     return null;
   }
@@ -10,11 +10,12 @@ const Modal = ({ isOpen, onClose, title, children, success }) => {
     <div className={success ? styles.modalOverlaySuccess : styles.modalOverlay}>
       <div className={`${styles.modalContent} ${success ? styles.modalSuccess : ''}`}>
         <div className={styles.modalHeader}>
-          <h2 className={styles.modalTitle}>{title}</h2>
+          <h2 className={`${styles.modalTitle} ${warning ? styles.modalWarn : ''}`}>{title}</h2>
           <span className={styles.modalCloseBtn} onClick={() => onClose()}>
             &times;
           </span>
         </div>
+        <p className={styles.modalText}>{text}</p>
         <div className={styles.modalChildren}>{children}</div>
       </div>
     </div>

--- a/src/Components/Shared/Modal/modal.module.css
+++ b/src/Components/Shared/Modal/modal.module.css
@@ -49,19 +49,25 @@
   letter-spacing: 0.5px;
 }
 
-
-.modalHeader {
-  display:flex;
-  justify-content: space-between;
-}
-
 .modalTitle {
   display: inline-block;
   width: 34vw;
   font-size: 2vw;
 }
 
+.modalWarn {
+  color: red;
+}
+
+.modalText{
+  align-self: center;
+  margin-bottom: 4vw;
+}
+
 .modalCloseBtn {
+  position:absolute;
+  top: 1vw;
+  right: 1vw;
   font-size: 2vw;
   width: 2vw;
   height: 2vw;

--- a/src/Components/Shared/Modal/modal.module.css
+++ b/src/Components/Shared/Modal/modal.module.css
@@ -16,9 +16,9 @@
 }
 
 .modalOverlaySuccess {
-  position: absolute;
-  top: 0;
-  right: 0;
+  position: fixed;
+  top: 1vw;
+  right: 1vw;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
The idea is that the "children" prop will only be used to add buttons and not text. 
The "text" prop will be a <p> element that will be centered. 
The "warning" prop will be a boolean that determines if the title should be displayed in red color.